### PR TITLE
Disable aspire authentication

### DIFF
--- a/collector/otel-collector-config.yaml
+++ b/collector/otel-collector-config.yaml
@@ -2,6 +2,7 @@ receivers:
   otlp:
     protocols:
       grpc:
+        endpoint: 0.0.0.0:4317
 
 exporters:
   debug:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
 
   collector:
@@ -53,10 +51,12 @@ services:
       - 3000:3000
 
   aspire:
-    image: mcr.microsoft.com/dotnet/nightly/aspire-dashboard
+    image: mcr.microsoft.com/dotnet/nightly/aspire-dashboard:latest
     restart: unless-stopped
     ports:
       - 18888:18888
+    environment:
+      - DOTNET_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS=true
 
 # Traces are ephemeral.
 # Logs and metrics are persisted.


### PR DESCRIPTION
Given that the purpose is Local telemetry, the Authentication token is quite annoying (to me). You can remove it by adding something to the environment variables. Thought you might want to use that too.

While I was at it, also explicitly configured the otel collector to bind to 0.0.0.0 as I was getting inconsistent behaviour